### PR TITLE
Rebuilt missing half of plant product descriptions

### DIFF
--- a/scripts/view-item-info.lua
+++ b/scripts/view-item-info.lua
@@ -249,7 +249,7 @@ end
 
 function get_plant_reaction_products (mat)
     local list = {}
-    add_react_prod (list, mat, "DRINK_MAT", "Used to brew ")
+--  add_react_prod (list, mat, "DRINK_MAT", "Used to brew ") -- redundant with the jury-rig in the next function
     add_react_prod (list, mat, "GROWTH_JUICE_PROD", "Pressed into ")
     add_react_prod (list, mat, "PRESS_LIQUID_MAT", "Pressed into ")
     add_react_prod (list, mat, "LIQUID_EXTRACTABLE", "Extractable product: ")
@@ -290,15 +290,26 @@ function GetFoodPropertiesStringList (item)
     if item._type == df.item_plantst and GetMatPlant (item) then
         local plant = GetMatPlant (item)
         for k,v in pairs (plant.material_defs) do
-            if v ~= -1 and string.find (k,"type_") and not string.find (k,"type_basic")
-                    or string.find (k,"type_seed") or string.find (k,"type_tree") then
+            if v ~= -1 and string.find (k,"type_") and not (string.find (k,"type_basic")
+                    or string.find (k,"type_seed") or string.find (k,"type_tree")) then
                 local targetmat = dfhack.matinfo.decode (v,
                     plant.material_defs["idx_"..string.match (k,"type_(.+)")])
                 local state = "Liquid"
-                if string.find (k,"type_mill") then state = "Powder"
-                elseif string.find (k,"type_thread") then state = "Solid" end
+                local describe = "Made into "
+                if string.find (k,"type_mill")
+                    then state = "Powder" describe = "Ground into "
+                elseif string.find (k,"type_thread")
+                    then state = "Solid" describe = "Woven into "
+                elseif string.find (k,"type_drink")
+                    then describe = "Brewed into "
+                elseif string.find (k,"type_extract_barrel")
+                    then describe = "Cask-aged into "
+                elseif string.find (k,"type_extract_vial")
+                    then describe = "Refined into vials of "
+                elseif string.find (k,"type_extract_still_vial")
+                    then describe = "Distilled into vials of " end
                 local st_name = targetmat.material.state_name[state]
-                append(list,"Used to make "..targetmat.material.prefix..''..st_name)
+                append(list,describe..targetmat.material.prefix..''..st_name)
             end
         end
     end


### PR DESCRIPTION
Turns out _get_plant_reaction_products is_ tuned to look for the specific material reaction products in the Natural Balance mod that this was originally designed around instead of looking at the basic item types.

The calls for liquid pressing, rendering, soapmaking and cheesemaking work exactly as they should, but the brewing stuff overlapped with the similar set of instructions in the next function and the milling/threshing/sugaring(?)/extracting/plastermaking were looking for tokens that just aren't there.
So what I did was comment out adding the DRINK_MAT material reaction product into the description and extended the mechanism at the ass-end of _GetFoodPropertiesStringList_ to handle basic products other than booze, thread and powder, using verbal descriptions with more than the same "made into" for everything.

Seeds are still asked nothing but their growth times and stuff like quarry bushes don't mention they can be threshed for growths (or seeds) at all, but at least it works for normal plants without coming up blank or barfing on the user's lap most of the time.
